### PR TITLE
Implementação das escalas menores harmônica e melódica

### DIFF
--- a/notas_musicais/cli.py
+++ b/notas_musicais/cli.py
@@ -17,7 +17,7 @@ def escalas(
     ),
     tonalidade=Argument(
         'maior',
-        help='Tonalidade da escala. Por exemplo: maior, menor, ...',
+        help='Tonalidade da escala. Por exemplo: maior, menor-natural, ...',
     ),
     harmonia: bool = Option(False),
 ):

--- a/notas_musicais/escalas.py
+++ b/notas_musicais/escalas.py
@@ -3,7 +3,9 @@
 NOTAS = 'C C# D D# E F F# G G# A A# B'.split()
 ESCALAS = {
     'maior': (0, 2, 4, 5, 7, 9, 11),
-    'menor': (0, 2, 3, 5, 7, 8, 10),
+    'menor-natural': (0, 2, 3, 5, 7, 8, 10),
+    'menor-harmonica': (0, 2, 3, 5, 7, 8, 11),
+    'menor-melodica': (0, 2, 3, 5, 7, 9, 11),
 }
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,7 +25,7 @@ def test_escala_cli_deve_conter_os_graus_no_stdout(grau):
     assert grau in result.stdout
 
 
-@mark.parametrize('tonica,tonalidade', [('C', 'maior'), ('D#', 'menor')])
+@mark.parametrize('tonica,tonalidade', [('C', 'maior'), ('D#', 'menor-natural')])
 def test_ecala_cli_deve_exibir_a_tonalidade_e_a_tonica(tonica, tonalidade):
     msg = f'Escala {tonalidade} de {tonica}'
     result = runner.invoke(app, [tonica, tonalidade])

--- a/tests/test_escalas.py
+++ b/tests/test_escalas.py
@@ -46,8 +46,48 @@ def test_escala_deve_retornar_notas_e_graus_da_escala_maior(tonica, notas):
         ('E', ['E', 'F#', 'G', 'A', 'B', 'C', 'D']),
     ],
 )
-def test_escala_deve_retornar_notas_e_graus_da_escala_menor(tonica, notas):
-    tonalidade = 'menor'
+def test_escala_deve_retornar_notas_e_graus_da_escala_menor_natural(tonica, notas):
+    tonalidade = 'menor-natural'
+    esperado = {
+        'notas': notas,
+        'graus': graus,
+    }
+
+    resultado = escala(tonica, tonalidade)
+
+    assert esperado == resultado
+
+
+@pytest.mark.parametrize(
+    'tonica,notas',
+    [
+        ('C', ['C', 'D', 'D#', 'F', 'G', 'G#', 'B']),
+        ('D', ['D', 'E', 'F', 'G', 'A', 'A#', 'C#']),
+        ('E', ['E', 'F#', 'G', 'A', 'B', 'C', 'D#']),
+    ],
+)
+def test_escala_deve_retornar_notas_e_graus_da_escala_menor_harmonica(tonica, notas):
+    tonalidade = 'menor-harmonica'
+    esperado = {
+        'notas': notas,
+        'graus': graus,
+    }
+
+    resultado = escala(tonica, tonalidade)
+
+    assert esperado == resultado
+
+
+@pytest.mark.parametrize(
+    'tonica,notas',
+    [
+        ('C', ['C', 'D', 'D#', 'F', 'G', 'A', 'B']),
+        ('D', ['D', 'E', 'F', 'G', 'A', 'B', 'C#']),
+        ('E', ['E', 'F#', 'G', 'A', 'B', 'C#', 'D#']),
+    ],
+)
+def test_escala_deve_retornar_notas_e_graus_da_escala_menor_melodica(tonica, notas):
+    tonalidade = 'menor-melodica'
     esperado = {
         'notas': notas,
         'graus': graus,


### PR DESCRIPTION
- Renomeia a escala `menor` para `menor-natural`.
- Adiciona as escalas `menor-harmonica` e `menor-melodica`.