### PR TITLE
Implementa escala cromática

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Embora isso seja somente uma recomendação! Você também pode instalar o proje
 pip install notas-musicais
 ```
 
-## como usar?
+## Como usar?
 
 ### Escalas
 

--- a/docs/02_contribua.md
+++ b/docs/02_contribua.md
@@ -33,7 +33,7 @@ Os exemplos usados na docstring também estão sendo usados para testes. Então,
 
 #### Sobre a biblioteca
 
-Toda a biblioteca usa python puro, ela não tem nenhuma dependência de bibliotecas externas. Isso é proposital, pois o código é bastante simples. As respostas das funções foram padronizadas com o retorno sempre sendo um dicionário python, pois em algum momento alguém pode querer expandir isso para uma interface gráfica ou usar em um API REST, dessa forma, acredito que um padrão que pode ser serealizado, pode ajudar bastante as pessoas.
+Toda a biblioteca usa python puro, ela não tem nenhuma dependência de bibliotecas externas. Isso é proposital, pois o código é bastante simples. As respostas das funções foram padronizadas com o retorno sempre sendo um dicionário python, pois em algum momento alguém pode querer expandir isso para uma interface gráfica ou usar em um API REST, dessa forma, acredito que um padrão que pode ser serializado, pode ajudar bastante as pessoas.
 
 Todas as vezes em que o código é consumido entre funções, durante a construção da aplicação foi criado um padrão para desempacotar o dicionário em outras funções. Então, não se preocupe se ver muito esse formato de código:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ Toda a aplicação é baseada em um comando chamado `notas-musicais`. Esse coman
 
 {% include "templates/instalacao.md" %}
 
-## como usar?
+## Como usar?
 
 ### Escalas
 

--- a/notas_musicais/escalas.py
+++ b/notas_musicais/escalas.py
@@ -7,7 +7,7 @@ Attributes:
 
 # ESCALAS
 
-A escalas estão implementadas em uma constande chamada `ESCALAS`. Que é um dicionário onde as chaves são as escalas. Se quiser ver todas as escalas implementadas pode usar:
+A escalas estão implementadas em uma constante chamada `ESCALAS`. Que é um dicionário onde as chaves são as escalas. Se quiser ver todas as escalas implementadas pode usar:
 
 ```py title="No seu shell interativo"
 >>> from notas_musicais.escalas import ESCALAS
@@ -25,7 +25,7 @@ tip: Dica!
 
 # NOTAS
 
-As notas estão sendo definidas em uma contasnte `NOTAS`. Foi optado por menter somente as notas no formato Natural e o Sustenido (#) para a simplificação do fluxo de trabalho. Embora não esteja totalmente correto. Para ver as 12 notas você pode:
+As notas estão sendo definidas em uma constante `NOTAS`. Foi optado por manter somente as notas no formato Natural e o Sustenido (#) para a simplificação do fluxo de trabalho. Embora não esteja totalmente correto. Para ver as 12 notas você pode:
 
 ```py title="No seu shell interativo"
 >>> from notas_musicais.escalas import NOTAS
@@ -35,16 +35,20 @@ As notas estão sendo definidas em uma contasnte `NOTAS`. Foi optado por menter 
 ```
 """
 NOTAS = 'C C# D D# E F F# G G# A A# B'.split()
-ESCALAS = {'maior': (0, 2, 4, 5, 7, 9, 11), 'menor': (0, 2, 3, 5, 7, 8, 10)}
+ESCALAS = {
+    'maior': (0, 2, 4, 5, 7, 9, 11),
+    'menor': (0, 2, 3, 5, 7, 8, 10),
+    'cromatica': (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+}
 
 
 def escala(tonica: str, tonalidade: str) -> dict[str, list[str]]:
     """
-    Gera uma escala apartir de uma tônica e uma tonalidade.
+    Gera uma escala a partir de uma tônica e uma tonalidade.
 
     Args:
         tonica: Nota que será a tônica da escala
-        tonalidade: Tonialidade da escala
+        tonalidade: Tonalidade da escala
 
     Returns:
         Um dicionário com as notas da escala e os graus.
@@ -68,7 +72,7 @@ def escala(tonica: str, tonalidade: str) -> dict[str, list[str]]:
         raise ValueError(f'Essa nota não existe, tente uma dessas {NOTAS}')
     except KeyError:
         raise KeyError(
-            'Essa escala não existe ou não foi implementada. '
+            'Essa escala não existe ou não foi implementada ainda. '
             f'Tente uma dessas {list(ESCALAS.keys())}'
         )
 

--- a/tests/test_escalas.py
+++ b/tests/test_escalas.py
@@ -38,7 +38,7 @@ def test_deve_retornar_um_erro_dizendo_que_a_escala_não_existe():
     tonalidade = 'tonalidade'
 
     mensagem_de_erro = (
-        'Essa escala não existe ou não foi implementada. '
+        'Essa escala não existe ou não foi implementada ainda. '
         f'Tente uma dessas {list(ESCALAS.keys())}'
     )
 
@@ -57,6 +57,21 @@ def test_deve_retornar_um_erro_dizendo_que_a_escala_não_existe():
         ('C', 'menor', ['C', 'D', 'D#', 'F', 'G', 'G#', 'A#']),
         ('C#', 'menor', ['C#', 'D#', 'E', 'F#', 'G#', 'A', 'B']),
         ('F', 'menor', ['F', 'G', 'G#', 'A#', 'C', 'C#', 'D#']),
+        (
+            'C',
+            'cromatica',
+            ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'],
+        ),
+        (
+            'C#',
+            'cromatica',
+            ['C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B', 'C'],
+        ),
+        (
+            'D',
+            'cromatica',
+            ['D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B', 'C', 'C#'],
+        ),
     ],
 )
 def test_deve_retornar_as_notas_corretas(tonica, tonalidade, esperado):


### PR DESCRIPTION
Esse PR busca implementar a escala cromática no `notas_musicais`.

## O que foi feito
- [x] Implementei a escala cromática, adicionando a tonalidade na constante `ESCALAS`;
- [x] Implementei novos testes parametrizados no `test_deve_retornar_um_erro_dizendo_que_a_escala_não_existe`;

## Pontos de discussão
- Pensei em utilizar o type annotation `Literal` pra tentar garantir que as tonalidades enviadas pelo usuário seriam apenas as  já implementadas, algo tipo:

```
from typing import Literal
Tonalidades = Literal['maior',  'menor', 'cromatica']
```

Mas acho que fugia do escopo do PR e talvez perdesse o sentido de alguns testes e validações como o `KeyError`, queria saber sua opinião sobre isso 🤔 

- Pensei sobre separar os testes parametrizados (em outro PR) deixando um teste pra cada tonalidade, porque ao longo do tempo provavelmente esse teste cresça bastante e dificulte a visibilidade do que ele está testando, o que acha?

## Extras
- [x] Corrigi alguns typos encontrados no caminho ~~perdão por manchar o PR mas o TOC não deixou passar batido, se quiser posso tirar esse commit daqui e abrir outro PR~~