### PR TITLE
Verificando a mensagem de erro diretamente

### DIFF
--- a/tests/test_escalas.py
+++ b/tests/test_escalas.py
@@ -4,6 +4,8 @@ AAA - 3A - A3
 Arange - Act - Assets!
 Arrumar - Agir - Garantir!
 """
+import re
+
 from pytest import mark, raises
 
 from notas_musicais.escalas import ESCALAS, NOTAS, escala
@@ -27,10 +29,8 @@ def test_deve_retornar_um_erro_dizendo_que_a_nota_nao_existe():
 
     mensagem_de_erro = f'Essa nota não existe, tente uma dessas {NOTAS}'
 
-    with raises(ValueError) as error:
+    with raises(ValueError, match=re.escape(mensagem_de_erro)) as error:
         escala(tonica, tonalidade)
-
-    assert mensagem_de_erro == error.value.args[0]
 
 
 def test_deve_retornar_um_erro_dizendo_que_a_escala_não_existe():
@@ -42,10 +42,8 @@ def test_deve_retornar_um_erro_dizendo_que_a_escala_não_existe():
         f'Tente uma dessas {list(ESCALAS.keys())}'
     )
 
-    with raises(KeyError) as error:
+    with raises(KeyError, match=re.escape(mensagem_de_erro)) as error:
         escala(tonica, tonalidade)
-
-    assert mensagem_de_erro == error.value.args[0]
 
 
 @mark.parametrize(


### PR DESCRIPTION
A função "raises" do pytest possui um parâmetro "match" que serve para verificar a mensagem diretamente dentro do contexto que gera um exceção esperada. Como a mensagem testada é literal, é necessário escapar de expressões regulares (usadas por padrão).

Referência:
https://docs.pytest.org/en/7.1.x/reference/reference.html#pytest.raises