### PR TITLE
Correcao do gramatica nos topicos de readme e index

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Embora isso seja somente uma recomendação! Você também pode instalar o proje
 pip install notas-musicais
 ```
 
-## como usar?
+## Como usar?
 
 ### Escalas
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ Toda a aplicação é baseada em um comando chamado `notas-musicais`. Esse coman
 
 {% include "templates/instalacao.md" %}
 
-## como usar?
+## Como usar?
 
 ### Escalas
 


### PR DESCRIPTION
Todos os topicos da documentação sao iniciados com letras maiúsculas. Encontrei o caso de "como usar" com letras minusculas, uma simples correção

ps: Estou acentos no teclado, pardao por isso :(