### PR TITLE
adicionando cache da instalação do poetry no processo de CI

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -8,14 +8,15 @@ jobs:
     steps:
       - name: Copia os arquivos do repo
         uses: actions/checkout@v3
+      
+      - name: Instalar Poetry
+        run: pipx install poetry
 
       - name: Instalar o python
         uses: actions/setup-python@v4
         with:
           python-version: '3.11.1'
-
-      - name: Instalar Poetry
-        run: pip install poetry
+          cache: 'poetry'
 
       - name: Instalar dependências do projeto
         run: poetry install --without doc


### PR DESCRIPTION
Cacheando instalação das bibliotecas no processo de setup do python no CI.
A referencia pode ser encontrada aqui:

[https://github.com/actions/setup-python#caching-packages-dependencies](https://github.com/actions/setup-python#caching-packages-dependencies)